### PR TITLE
Added calibrate_urban

### DIFF
--- a/onsstove/onsstove.py
+++ b/onsstove/onsstove.py
@@ -250,7 +250,33 @@ class OnSSTOVE():
         elif method=='read':
             self.df[layer.name] = layer.layer[self.rows, self.cols]
 
-    
+    def calibrate_urban(self):
+
+        urban_modelled = 2
+        factor = 1
+        pop_tot = self.specs["Population_start_year"]
+        urban_current = self.specs["Urban_start"]
+
+        i = 0
+        while abs(urban_modelled - urban_current) > 0.01:
+
+            self.df["IsUrban"] = 0
+            self.df.loc[(self.df["Population"] > 300 * factor), "IsUrban"] = 1
+            self.df.loc[(self.df["Population"] > 1500 * factor), "IsUrban"] = 2
+
+            pop_urb = self.df.loc[clusters["IsUrban"] > 1, "Calibrated_pop"].sum()
+
+            urban_modelled = pop_urb / pop_tot
+
+            if urban_modelled > urban_current:
+                factor *= 1.1
+            else:
+                factor *= 0.9
+            i = i + 1
+            if i > 500:
+                break
+
+
     def save_datasets(self, datasets='all'):
         """
         Saves all layers that have not been previously saved

--- a/onsstove/onsstove.py
+++ b/onsstove/onsstove.py
@@ -260,11 +260,13 @@ class OnSSTOVE():
         i = 0
         while abs(urban_modelled - urban_current) > 0.01:
 
-            self.df["IsUrban"] = 0
-            self.df.loc[(self.df["Population"] > 300 * factor), "IsUrban"] = 1
-            self.df.loc[(self.df["Population"] > 1500 * factor), "IsUrban"] = 2
+            self.gdf["IsUrban"] = 0
+            self.gdf.loc[(self.gdf["Population"] > 5000 * factor) & (
+                    self.gdf["Population"] / self.cell_size > 350 * factor), "IsUrban"] = 1
+            self.gdf.loc[(self.gdf["Population"] > 50000 * factor) & (
+                    self.gdf["Population"] / self.cell_size > 1500 * factor), "IsUrban"] = 2
 
-            pop_urb = self.df.loc[clusters["IsUrban"] > 1, "Calibrated_pop"].sum()
+            pop_urb = self.gdf.loc[clusters["IsUrban"] > 1, "Calibrated_pop"].sum()
 
             urban_modelled = pop_urb / pop_tot
 
@@ -275,7 +277,6 @@ class OnSSTOVE():
             i = i + 1
             if i > 500:
                 break
-
 
     def save_datasets(self, datasets='all'):
         """


### PR DESCRIPTION
1) Reads urban ratio from specs file
2) sums total calibrated population
3) classifies rows as urban and rural, ensuring that the total urban ratio at the end is within 1% of the actual urban ratio.

This closes #40