### PR TITLE
Travel time maps for LPG and Biogass

### DIFF
--- a/onsstove/layer.py
+++ b/onsstove/layer.py
@@ -8,7 +8,7 @@ from skimage.graph.mcp import MCP_Geometric
 from .raster import *
 
 
-class Layer():
+class Layer:
     """
     Template Layer initializing all needed variables.
     """
@@ -159,9 +159,14 @@ class VectorLayer(Layer):
         self.layer.to_file(output_file, driver='GeoJSON')
         self.path = output_file
 
-    def add_friction_raster(self, raster_path, resample='nearest'):
-        self.friction = RasterLayer(self.category, self.name + ' - friction',
-                                    raster_path, resample=resample)
+    def add_friction_raster(self, raster, resample='nearest'):
+        if isinstance(raster, str):
+            self.friction = RasterLayer(self.category, self.name + ' - friction',
+                                        raster, resample=resample)
+        elif isinstance(raster, RasterLayer):
+            self.friction = raster
+        else:
+            raise ValueError('Raster file type or object not recognized.')
 
     def add_restricted_areas(self, layer_path, layer_type, **kwargs):
         if layer_type == 'vector':
@@ -262,12 +267,17 @@ class RasterLayer(Layer):
         with rasterio.open(output_file, "w", **self.meta) as dest:
             dest.write(self.layer, indexes=1)
 
-    def add_friction_raster(self, raster_path, starting_cells=[1],
+    def add_friction_raster(self, raster, starting_cells=[1],
                             resample='nearest'):
         self.starting_cells = starting_cells
-        self.friction = RasterLayer(self.category,
-                                    self.name + ' - friction',
-                                    raster_path, resample=resample)
+        if isinstance(raster, str):
+            self.friction = RasterLayer(self.category,
+                                        self.name + ' - friction',
+                                        raster, resample=resample)
+        elif isinstance(raster, RasterLayer):
+            self.friction = raster
+        else:
+            raise ValueError('Raster file type or object not recognized.')
 
     def align(self, base_layer, output_path):
         layer, meta = align_raster(base_layer, self.path,

--- a/onsstove/onsstove.py
+++ b/onsstove/onsstove.py
@@ -6,7 +6,7 @@ import geopandas as gpd
 import numpy as np
 from typing import Dict, Any
 
-from onsstove.technology import Technology
+from onsstove.technology import Technology, LPG, Biomass
 from .raster import *
 from .layer import VectorLayer, RasterLayer
 
@@ -84,7 +84,12 @@ class OnSSTOVE():
             for row in config_file:
                 if row['Value']:
                     if row['Fuel'] not in techs:
-                        techs[row['Fuel']] = Technology()
+                        if row['Fuel'] == 'LPG':
+                            techs[row['Fuel']] = LPG()
+                        elif 'biomass' in row['Fuel'].lower():
+                            techs[row['Fuel']] = Biomass()
+                        else:
+                            techs[row['Fuel']] = Technology()
                     if row['data_type'] == 'int':
                         techs[row['Fuel']][row['Param']] = int(row['Value'])
                     elif row['data_type'] == 'float':


### PR DESCRIPTION
This PR closes #39. It creates two `Technology` subclasses `LPG` and `Biomass` and allows the user to add a `travel_time` layer to them, previously created using the `VectorLayer` and `RasterLayer` classes. Implementation notes can be found in #39.